### PR TITLE
blender-bin: respect original nixpkgs in overlays

### DIFF
--- a/blender/flake.nix
+++ b/blender/flake.nix
@@ -7,12 +7,12 @@
 
     let
 
-      pkgs = import nixpkgs {
+      new-pkgs = import nixpkgs {
         system = "x86_64-linux";
         overlays = [ self.overlays.default ];
       };
 
-      mkBlender = { pname, version, src }:
+      mkBlender = { pkgs, pname, version, src }:
         with pkgs;
 
         stdenv.mkDerivation rec {
@@ -47,7 +47,7 @@
         };
 
       mkTest = { blender }:
-        pkgs.runCommand "blender-test" { buildInputs = [ blender ]; }
+        new-pkgs.runCommand "blender-test" { buildInputs = [ blender ]; }
           ''
             blender --version
             touch $out
@@ -58,6 +58,7 @@
       overlays.default = final: prev: {
 
         blender_2_79 = mkBlender {
+          pkgs = final;
           pname = "blender-bin";
           version = "2.79-20190523-054dbb833e15";
           src = import <nix/fetchurl.nix> {
@@ -67,6 +68,7 @@
         };
 
         blender_2_81 = mkBlender {
+          pkgs = final;
           pname = "blender-bin";
           version = "2.81a";
           src = import <nix/fetchurl.nix> {
@@ -76,6 +78,7 @@
         };
 
         blender_2_82 = mkBlender {
+          pkgs = final;
           pname = "blender-bin";
           version = "2.82a";
           src = import <nix/fetchurl.nix> {
@@ -85,6 +88,7 @@
         };
 
         blender_2_83 = mkBlender {
+          pkgs = final;
           pname = "blender-bin";
           version = "2.83.9";
           src = import <nix/fetchurl.nix> {
@@ -94,6 +98,7 @@
         };
 
         blender_2_90 = mkBlender {
+          pkgs = final;
           pname = "blender-bin";
           version = "2.90.1";
           src = import <nix/fetchurl.nix> {
@@ -103,6 +108,7 @@
         };
 
         blender_2_91 = mkBlender {
+          pkgs = final;
           pname = "blender-bin";
           version = "2.91.2";
           src = import <nix/fetchurl.nix> {
@@ -112,6 +118,7 @@
         };
 
         blender_2_92 = mkBlender {
+          pkgs = final;
           pname = "blender-bin";
           version = "2.92.0";
           src = import <nix/fetchurl.nix> {
@@ -121,6 +128,7 @@
         };
 
         blender_2_93 = mkBlender {
+          pkgs = final;
           pname = "blender-bin";
           version = "2.93.7";
           src = import <nix/fetchurl.nix> {
@@ -130,6 +138,7 @@
         };
 
         blender_3_0 = mkBlender {
+          pkgs = final;
           pname = "blender-bin";
           version = "3.0.1";
           src = import <nix/fetchurl.nix> {
@@ -139,6 +148,7 @@
         };
 
         blender_3_1 = mkBlender {
+          pkgs = final;
           pname = "blender-bin";
           version = "3.1.2";
           src = import <nix/fetchurl.nix> {
@@ -150,7 +160,7 @@
       };
 
       packages.x86_64-linux = rec {
-        inherit (pkgs)
+        inherit (new-pkgs)
           blender_2_79
           blender_2_81
           blender_2_82


### PR DESCRIPTION
This means you no longer have to specify the “follows” predicate if you want Blender to work with a flake that has a newer or older nixpkgs in use for its OpenGL system
