### PR TITLE
Add required libraries for running blender 3.4 with wayland

### DIFF
--- a/blender/flake.nix
+++ b/blender/flake.nix
@@ -37,7 +37,7 @@
               mkdir $out/bin
 
               makeWrapper $out/libexec/blender/blender $out/bin/blender \
-                --prefix LD_LIBRARY_PATH : /run/opengl-driver/lib:${lib.makeLibraryPath [ xorg.libX11 xorg.libXi xorg.libXxf86vm xorg.libXfixes xorg.libXrender libxkbcommon libGLU libglvnd numactl SDL2 libdrm ocl-icd stdenv.cc.cc.lib ]}
+                --prefix LD_LIBRARY_PATH : /run/opengl-driver/lib:${lib.makeLibraryPath [ wayland xorg.libX11 xorg.libXi xorg.libXxf86vm xorg.libXfixes xorg.libXrender libxkbcommon libGLU libglvnd numactl SDL2 libdrm ocl-icd stdenv.cc.cc.lib ]}
 
               patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
                 blender/blender

--- a/blender/flake.nix
+++ b/blender/flake.nix
@@ -37,7 +37,7 @@
               mkdir $out/bin
 
               makeWrapper $out/libexec/blender/blender $out/bin/blender \
-                --prefix LD_LIBRARY_PATH : /run/opengl-driver/lib:${lib.makeLibraryPath [ wayland xorg.libX11 xorg.libXi xorg.libXxf86vm xorg.libXfixes xorg.libXrender libxkbcommon libGLU libglvnd numactl SDL2 libdrm ocl-icd stdenv.cc.cc.lib ]}
+                --prefix LD_LIBRARY_PATH : /run/opengl-driver/lib:${lib.makeLibraryPath [ wayland libdecor xorg.libX11 xorg.libXi xorg.libXxf86vm xorg.libXfixes xorg.libXrender libxkbcommon libGLU libglvnd numactl SDL2 libdrm ocl-icd stdenv.cc.cc.lib ]}
 
               patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
                 blender/blender


### PR DESCRIPTION
Hi,

I wanted to try the new wayland support in blender 3.4, but it requires a couple of new libraries (libwayland-client and libdecor).

This PR adds them both to `mkBlender`. I'm happy to modify it to only install them for blender 3.4 if you have suggestions about how you'd prefer to do that. Similarly, [libdecor is only required for gnome shell ](https://code.blender.org/2022/10/wayland-support-on-linux/) so that could also be made optional.

Thanks!