### PR TITLE
blender-bin: add OpenAL to libs

### DIFF
--- a/blender/flake.nix
+++ b/blender/flake.nix
@@ -17,7 +17,7 @@
 
         let
           libs =
-            [ wayland libdecor xorg.libX11 xorg.libXi xorg.libXxf86vm xorg.libXfixes xorg.libXrender libxkbcommon libGLU libglvnd numactl SDL2 libdrm ocl-icd stdenv.cc.cc.lib ]
+            [ wayland libdecor xorg.libX11 xorg.libXi xorg.libXxf86vm xorg.libXfixes xorg.libXrender libxkbcommon libGLU libglvnd numactl SDL2 libdrm ocl-icd stdenv.cc.cc.lib openal ]
             ++ lib.optionals (lib.versionAtLeast version "3.5") [ xorg.libSM xorg.libICE zlib ];
         in
 


### PR DESCRIPTION
fixes #16

Blender uses OpenAL by default, but I don't know which is the earliest version, so I just added it in general.